### PR TITLE
Entitlement picker for when search returns more than one entitlement

### DIFF
--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -108,6 +108,10 @@ func runTask(cmd *cobra.Command, args []string, run func(c client.C1Client, ctx 
 			appId = client.StringFromPtr(entitlement.List[0].AppEntitlement.AppId)
 		}
 		if len(entitlement.List) > 1 {
+			isNonInteractive := v.GetBool("non-interactive")
+			if isNonInteractive {
+				return fmt.Errorf("multiple entitlements found with alias %s, please specify an entitlement id and app id", alias)
+			}
 			optionToEntitlementMap := make(map[string]c1api.C1ApiAppV1AppEntitlementView)
 			entitlementOptions := make([]string, len(entitlement.List))
 			for _, e := range entitlement.List {

--- a/cmd/cone/main.go
+++ b/cmd/cone/main.go
@@ -46,8 +46,7 @@ func runCli(ctx context.Context) int {
 	}
 
 	cliCmd.PersistentFlags().StringP("profile", "p", "default", "The config profile to use.")
-	// TODO: Interactive mode doesn't exist, so non-interactive doesn't change anything
-	// cliCmd.PersistentFlags().BoolP("non-interactive", "i", false, "Disable prompts.")
+	cliCmd.PersistentFlags().BoolP("non-interactive", "i", false, "Disable prompts.")
 	cliCmd.PersistentFlags().String("client-id", "", "Client ID")
 	cliCmd.PersistentFlags().String("client-secret", "", "Client secret")
 	cliCmd.PersistentFlags().String("config-path", "", "path to config file")


### PR DESCRIPTION
This PR adds an entitlement picker for when search returns more than a single entitlement.
![Screen Shot 2023-06-01 at 4 39 17 PM](https://github.com/ConductorOne/cone/assets/98769258/36f37237-08d1-4163-ae0c-652aa615d3c3)
