### PR TITLE
Grant duration error is displayed to user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 *.db
 *.csv
 *.xlsx
+.vscode
+.DS_Store
 
 # Test binary, built with `go test -c`
 *.test


### PR DESCRIPTION
Code now casts the error into a GenericOpenApiError (if possible) and then checks if the error is a GrantDurationError. If it is it will let the user know about it.