### PR TITLE
Visual Updates

### DIFF
--- a/cmd/cone/search_entitlements.go
+++ b/cmd/cone/search_entitlements.go
@@ -61,8 +61,13 @@ type ExpandedEntitlementsResponse struct {
 }
 
 func (r *ExpandedEntitlementsResponse) Header() []string {
-	return []string{"Granted", "Id", "Display Name", "App", "Resource Type", "Resource", "Alias", "Description"}
+	return []string{"", "Alias", "Display Name", "App", "Resource Type", "Resource"}
 }
+
+func (r *ExpandedEntitlementsResponse) WideHeader() []string {
+	return append(r.Header(), []string{"Description"}...)
+}
+
 func (r *ExpandedEntitlementsResponse) Rows() [][]string {
 	rows := [][]string{}
 	for _, e := range r.entitlements {
@@ -77,21 +82,27 @@ func (r *ExpandedEntitlementsResponse) Rows() [][]string {
 			client.StringFromPtr(e.Entitlement.AppResourceID),
 		)
 
-		granted := "✅"
+		granted := "✓"
 		if len(e.Bindings) == 0 {
-			granted = "❌"
+			granted = ""
 		}
 
 		rows = append(rows, []string{
 			granted,
-			client.StringFromPtr(e.Entitlement.ID),
+			client.StringFromPtr(e.Entitlement.Alias),
 			client.StringFromPtr(e.Entitlement.DisplayName),
 			client.StringFromPtr(app.DisplayName),
 			client.StringFromPtr(resourceType.DisplayName),
 			client.StringFromPtr(resource.DisplayName),
-			client.StringFromPtr(e.Entitlement.Alias),
-			client.StringFromPtr(e.Entitlement.Description),
 		})
+	}
+	return rows
+}
+
+func (r *ExpandedEntitlementsResponse) WideRows() [][]string {
+	rows := r.Rows()
+	for i, e := range r.entitlements {
+		rows[i] = append(rows[i], client.StringFromPtr(e.Entitlement.Description))
 	}
 	return rows
 }

--- a/cmd/cone/search_entitlements.go
+++ b/cmd/cone/search_entitlements.go
@@ -65,7 +65,7 @@ func (r *ExpandedEntitlementsResponse) Header() []string {
 }
 
 func (r *ExpandedEntitlementsResponse) WideHeader() []string {
-	return append(r.Header(), []string{"Description"}...)
+	return append(r.Header(), "Description")
 }
 
 func (r *ExpandedEntitlementsResponse) Rows() [][]string {


### PR DESCRIPTION
Search table is not as wide.

Dropped id, included description only when using --output wide, granted column rework
<img width="985" alt="image" src="https://github.com/ConductorOne/cone/assets/60042005/beba66f6-d041-4adb-8911-38dfac1de161">
