### PR TITLE
Implement `cone has <app-id> <entitlement-id>`

### DIFF
--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -71,6 +71,7 @@ func hasRun(cmd *cobra.Command, args []string) error {
 	for _, grant := range grants {
 		if grant.CreatedAt != nil && grant.DeletedAt == nil {
 			hasObj.Has = output.Checkmark
+			break
 		}
 	}
 

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func hasCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "has <app-id> <app-entitlement-id>",
+		Short: "Check if the current user ",
+		RunE:  hasRun,
+	}
+
+	return cmd
+}
+
+func hasRun(cmd *cobra.Command, args []string) error {
+	ctx, c, v, err := cmdContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	if len(args) != 2 {
+		return fmt.Errorf("expected 2 argument, got %d", len(args))
+	}
+
+	userIntro, err := c.AuthIntrospect(ctx)
+	if err != nil {
+		return err
+	}
+
+	appID := args[0]
+	entitlementID := args[1]
+
+	introspectResp, err := c.GetGrantsForIdentity(ctx, appID, entitlementID, *userIntro.UserID)
+	if err != nil {
+		return err
+	}
+
+	for x := range introspectResp {
+		fmt.Println(introspectResp[x].AppEntitlementID)
+	}
+	print(v)
+
+	/*
+		resp := User(*userResp)
+		outputManager := output.NewManager(ctx, v)
+		err = outputManager.Output(ctx, &resp)
+		if err != nil {
+			return err
+		}
+	*/
+	return nil
+
+}

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -39,19 +39,17 @@ func hasRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("expected 2 arguments, got %d"+usageString, len(args))
 	}
 
+	appID := args[0]
+	entitlementID := args[1]
+
 	userIntro, err := c.AuthIntrospect(ctx)
 	if err != nil {
 		return err
 	}
-
-	appID := args[0]
-	entitlementID := args[1]
-
 	grants, err := c.GetGrantsForIdentity(ctx, appID, entitlementID, client.StringFromPtr(userIntro.UserID))
 	if err != nil {
 		return err
 	}
-
 	app, err := c.GetApp(ctx, appID)
 	if err != nil {
 		return err

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -37,7 +37,6 @@ func hasRun(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		usageString := "\nUsage:  cone has <app-id> <app-entitlement-id>"
 		return fmt.Errorf("expected 2 arguments, got %d"+usageString, len(args))
-
 	}
 
 	userIntro, err := c.AuthIntrospect(ctx)

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -60,7 +60,7 @@ func hasRun(cmd *cobra.Command, args []string) error {
 	}
 
 	hasObj := HasAppEntitlement{
-		Has:              pterm.Red("x"),
+		Has:              "",
 		AppEntitlementId: entitlementID,
 		AppId:            appID,
 		AppName:          client.StringFromPtr(app.DisplayName),

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -21,7 +21,7 @@ type HasAppEntitlement struct {
 func hasCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "has <app-id> <app-entitlement-id>",
-		Short: "Check if the current user ",
+		Short: "Check if the current user has a specific entitlement for an app",
 		RunE:  hasRun,
 	}
 
@@ -35,7 +35,9 @@ func hasRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(args) != 2 {
-		return fmt.Errorf("expected 2 arguments, got %d", len(args))
+		usageString := "\nUsage:  cone has <app-id> <app-entitlement-id>"
+		return fmt.Errorf("expected 2 arguments, got %d"+usageString, len(args))
+
 	}
 
 	userIntro, err := c.AuthIntrospect(ctx)

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/conductorone/cone/pkg/client"
 	"github.com/conductorone/cone/pkg/output"
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +59,7 @@ func hasRun(cmd *cobra.Command, args []string) error {
 	}
 
 	hasObj := HasAppEntitlement{
-		Has:              "",
+		Has:              output.Unchecked,
 		AppEntitlementId: entitlementID,
 		AppId:            appID,
 		AppName:          client.StringFromPtr(app.DisplayName),
@@ -70,7 +69,7 @@ func hasRun(cmd *cobra.Command, args []string) error {
 
 	for _, grant := range grants {
 		if grant.CreatedAt != nil && grant.DeletedAt == nil {
-			hasObj.Has = pterm.Green("✓")
+			hasObj.Has = output.Checkmark
 		}
 	}
 

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -82,7 +82,6 @@ func hasRun(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-
 }
 
 func (r *HasAppEntitlement) Header() []string {

--- a/cmd/cone/main.go
+++ b/cmd/cone/main.go
@@ -65,6 +65,7 @@ func runCli(ctx context.Context) int {
 	cliCmd.AddCommand(searchEntitlementsCmd())
 	cliCmd.AddCommand(tasksCmd())
 	cliCmd.AddCommand(loginCmd())
+	cliCmd.AddCommand(hasCmd())
 
 	err = cliCmd.ExecuteContext(ctx)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -74,7 +74,7 @@ type C1Client interface {
 		identityUserId string,
 		justification string,
 	) (*shared.TaskServiceCreateRevokeResponse, error)
-	GetGrantsForIdentity(ctx context.Context, appID string, appEntitlementID string, appUserID string) ([]shared.AppEntitlementUserBinding, error)
+	GetGrantsForIdentity(ctx context.Context, appID string, appEntitlementID string, identityID string) ([]shared.AppEntitlementUserBinding, error)
 	SearchTasks(ctx context.Context, taskFilter shared.TaskSearchRequest) (*shared.TaskSearchResponse, error)
 	CommentOnTask(ctx context.Context, taskID string, comment string) (*shared.TaskActionsServiceCommentResponse, error)
 	ApproveTask(ctx context.Context, taskId string, comment string, policyId string) (*shared.TaskActionsServiceApproveResponse, error)


### PR DESCRIPTION
Implemented the 'cone has' command.
<img width="540" alt="image" src="https://github.com/ConductorOne/cone/assets/93247310/4ee62835-3225-46e1-87fe-e52884e3688b">
