### PR TITLE
Fix 400 bad request when running cone get/drop.

### DIFF
--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -379,7 +379,11 @@ func getEntitlementDetails(ctx context.Context, c client.C1Client, v *viper.Vipe
 	}
 
 	// If we have an alias or query, search
-	entitlements, err := c.SearchEntitlements(ctx, &client.SearchEntitlementsFilter{EntitlementAlias: alias, Query: query})
+	entitlements, err := c.SearchEntitlements(ctx, &client.SearchEntitlementsFilter{
+		EntitlementAlias: alias,
+		Query:            query,
+		GrantedStatus:    shared.RequestCatalogSearchServiceSearchEntitlementsRequestGrantedStatusAll,
+	})
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
When searching for the entitlement to get/drop, we were sending a grantStatus of empty string, which gave 400 bad request. I'm not sure if we should send "UNSPECIFIED", or "ALL", or omit the field (have toPointer() return nil if the value is "").