### PR TITLE
Cone token command

### DIFF
--- a/cmd/cone/flags.go
+++ b/cmd/cone/flags.go
@@ -18,6 +18,7 @@ const (
 	extraDetailsFlag     = "detailed"
 	grantedFlag          = "granted"
 	notGrantedFlag       = "not-granted"
+	rawTokenFlag         = "raw"
 )
 
 func addWaitFlag(cmd *cobra.Command) {
@@ -67,4 +68,8 @@ func addForceTaskCreateFlag(cmd *cobra.Command) {
 
 func addEntitlementDetailsFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool(extraDetailsFlag, false, "Show more details about the app and entitlement for this request")
+}
+
+func addRawTokenFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool(rawTokenFlag, false, "Prints only the access token")
 }

--- a/cmd/cone/flags.go
+++ b/cmd/cone/flags.go
@@ -71,5 +71,5 @@ func addEntitlementDetailsFlag(cmd *cobra.Command) {
 }
 
 func addRawTokenFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool(rawTokenFlag, false, "Prints only the access token")
+	cmd.Flags().Bool(rawTokenFlag, false, "Prints only the access token directly to stdout with out style")
 }

--- a/cmd/cone/main.go
+++ b/cmd/cone/main.go
@@ -66,6 +66,7 @@ func runCli(ctx context.Context) int {
 	cliCmd.AddCommand(tasksCmd())
 	cliCmd.AddCommand(loginCmd())
 	cliCmd.AddCommand(hasCmd())
+	cliCmd.AddCommand(tokenCmd())
 
 	err = cliCmd.ExecuteContext(ctx)
 	if err != nil {

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 
+	"github.com/conductorone/cone/pkg/client"
+
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +19,12 @@ func tokenCmd() *cobra.Command {
 }
 
 func tokenRun(cmd *cobra.Command, args []string) error {
-	ctx, c, v, err := cmdContext(cmd)
+	ctx, _, v, err := cmdContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	clientId, clientSecret, err := getCredentials(v)
 	if err != nil {
 		return err
 	}
@@ -26,6 +33,18 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 		usageErrorString := cmd.UsageString()
 		return fmt.Errorf("expected 0 arguments, got %d\n"+usageErrorString, len(args))
 	}
+
+	tokenSrc, _, _, err := client.NewC1TokenSource(ctx, clientId, clientSecret)
+	if err != nil {
+		return err
+	}
+
+	token, err := tokenSrc.Token()
+	if err != nil {
+		return err
+	}
+
+	print(token)
 
 	return nil
 }

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -4,9 +4,16 @@ import (
 	"fmt"
 
 	"github.com/conductorone/cone/pkg/client"
+	"github.com/conductorone/cone/pkg/output"
 
 	"github.com/spf13/cobra"
 )
+
+type Token struct {
+	AccessToken string `header:"access_token"`
+	TokenType   string `header:"token_type"`
+	Expiry      string `header:"expiry"`
+}
 
 func tokenCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -14,7 +21,7 @@ func tokenCmd() *cobra.Command {
 		Short: "",
 		RunE:  tokenRun,
 	}
-
+	addRawTokenFlag(cmd)
 	return cmd
 }
 
@@ -44,7 +51,42 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	print(token)
+	tokenObj := Token{
+		AccessToken: token.AccessToken,
+		TokenType:   token.TokenType,
+		Expiry:      token.Expiry.String(),
+	}
+
+	if v.GetBool(rawTokenFlag) {
+		fmt.Println(tokenObj.AccessToken)
+		return nil
+	}
+
+	outputManager := output.NewManager(ctx, v)
+	err = outputManager.Output(ctx, &tokenObj, output.WithTransposeTable())
+	if err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func (r *Token) Header() []string {
+	return []string{
+		"Access Token",
+		"Token Type",
+		"Expiry",
+	}
+}
+
+func (r *Token) rows() []string {
+	return []string{
+		r.AccessToken,
+		r.TokenType,
+		r.Expiry,
+	}
+}
+
+func (r *Token) Rows() [][]string {
+	return [][]string{r.rows()}
 }

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -58,6 +58,7 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if v.GetBool(rawTokenFlag) {
+		//nolint:forbidigo // We want to raw-print the bearer if this flag is included
 		fmt.Println(tokenObj.AccessToken)
 		return nil
 	}

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func tokenCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "",
+		RunE:  tokenRun,
+	}
+
+	return cmd
+}
+
+func tokenRun(cmd *cobra.Command, args []string) error {
+	ctx, c, v, err := cmdContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	if len(args) != 0 {
+		usageErrorString := cmd.UsageString()
+		return fmt.Errorf("expected 0 arguments, got %d\n"+usageErrorString, len(args))
+	}
+
+	return nil
+}

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -10,9 +10,9 @@ import (
 )
 
 type Token struct {
-	AccessToken string `header:"access_token"`
-	TokenType   string `header:"token_type"`
-	Expiry      string `header:"expiry"`
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Expiry      string `json:"expiry"`
 }
 
 func tokenCmd() *cobra.Command {
@@ -59,7 +59,7 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 
 	if v.GetBool(rawTokenFlag) {
 		//nolint:forbidigo // We want to raw-print the bearer if this flag is included
-		fmt.Println(tokenObj.AccessToken)
+		fmt.Println(token.AccessToken)
 		return nil
 	}
 


### PR DESCRIPTION
Implemented "cone token" to display a token as a struct with a "--raw" flag that only prints the access token
<img width="975" alt="image" src="https://github.com/ConductorOne/cone/assets/93247310/0c16c3f2-d650-41d3-abf9-048843c1cc03">
