### PR TITLE
Validate Arg Length

### DIFF
--- a/cmd/cone/cmd.go
+++ b/cmd/cone/cmd.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/conductorone/cone/pkg/client"
 	"github.com/spf13/cobra"
@@ -27,4 +28,12 @@ func cmdContext(cmd *cobra.Command) (context.Context, client.C1Client, *viper.Vi
 	}
 
 	return ctx, c, v, nil
+}
+
+func validateArgLenth(expectedCount int, args []string, cmd *cobra.Command) error {
+	if len(args) == expectedCount {
+		return nil
+	}
+
+	return fmt.Errorf("expected %d arguments, got %d\n%s", expectedCount, len(args), cmd.UsageString())
 }

--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -26,7 +26,7 @@ const justificationInputTip = "You can add a justification using -j or --justifi
 
 func getCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <alias> \n  cone get --query <query> \n  cone get --app-id <app-id> --entitlement-id <entitlement-id>",
+		Use:   "get <alias> [flags]\n  cone get --query <query> [flags]\n  cone get --app-id <app-id> --entitlement-id <entitlement-id> [flags]",
 		Short: "Create an access request for an entitlement by alias",
 		RunE:  runGet,
 	}
@@ -37,7 +37,7 @@ func getCmd() *cobra.Command {
 
 func dropCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "drop",
+		Use:   "drop <alias> [flags]\n  cone drop --query <query> [flags]\n  cone drop --app-id <app-id> --entitlement-id <entitlement-id> [flags]",
 		Short: "Create a revoke access ticket for an entitlement by alias",
 		RunE:  runDrop,
 	}

--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -26,7 +26,7 @@ const justificationInputTip = "You can add a justification using -j or --justifi
 
 func getCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get",
+		Use:   "get <alias> \n  cone get --query <query> \n  cone get --app-id <app-id> --entitlement-id <entitlement-id>",
 		Short: "Create an access request for an entitlement by alias",
 		RunE:  runGet,
 	}

--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -288,7 +288,7 @@ func runTask(
 
 	justification := v.GetString(justificationFlag)
 
-	entitlementId, appId, err := getEntitlementDetails(ctx, c, v, args)
+	entitlementId, appId, err := getEntitlementDetails(ctx, c, v, args, cmd)
 	if err != nil {
 		return err
 	}
@@ -355,7 +355,7 @@ func runTask(
 	return nil
 }
 
-func getEntitlementDetails(ctx context.Context, c client.C1Client, v *viper.Viper, args []string) (string, string, error) {
+func getEntitlementDetails(ctx context.Context, c client.C1Client, v *viper.Viper, args []string, cmd *cobra.Command) (string, string, error) {
 	entitlementId := v.GetString(entitlementIdFlag)
 	appId := v.GetString(appIdFlag)
 	query := v.GetString(queryFlag)
@@ -366,11 +366,11 @@ func getEntitlementDetails(ctx context.Context, c client.C1Client, v *viper.Vipe
 	}
 
 	if alias == "" && query == "" && (appId == "" || entitlementId == "") {
-		return "", "", fmt.Errorf("must provide either an alias, query string, or an entitlement id and app id")
+		return "", "", fmt.Errorf("must provide either an alias, query string, or an entitlement id and app id\n%s", cmd.UsageString())
 	}
 
 	if (alias != "" || query != "") && (appId != "" || entitlementId != "") {
-		return "", "", fmt.Errorf("cannot provide an alias or query and an entitlement id and app id")
+		return "", "", fmt.Errorf("cannot provide an alias or query and an entitlement id and app id\n%s", cmd.UsageString())
 	}
 
 	// If we have an appId and appEntitlementId, just return those

--- a/cmd/cone/get_user.go
+++ b/cmd/cone/get_user.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/conductorone/conductorone-sdk-go/pkg/models/shared"
@@ -26,9 +24,7 @@ func getUserRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(args) != 1 {
-		return fmt.Errorf("expected 1 argument, got %d", len(args))
-	}
+	validateArgLenth(1, args, cmd)
 	userID := args[0]
 
 	userResp, err := c.GetUser(ctx, userID)

--- a/cmd/cone/get_user.go
+++ b/cmd/cone/get_user.go
@@ -24,7 +24,9 @@ func getUserRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	validateArgLenth(1, args, cmd)
+	if err := validateArgLenth(1, args, cmd); err != nil {
+		return err
+	}
 	userID := args[0]
 
 	userResp, err := c.GetUser(ctx, userID)

--- a/cmd/cone/get_user.go
+++ b/cmd/cone/get_user.go
@@ -10,7 +10,7 @@ import (
 
 func getUserCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get-user",
+		Use:   "get-user <user-id>",
 		Short: "Get a user by id",
 		RunE:  getUserRun,
 	}

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -33,7 +33,9 @@ func hasRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	validateArgLenth(2, args, cmd)
+	if err := validateArgLenth(2, args, cmd); err != nil {
+		return err
+	}
 
 	appID := args[0]
 	entitlementID := args[1]

--- a/cmd/cone/has.go
+++ b/cmd/cone/has.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/conductorone/cone/pkg/client"
@@ -34,10 +33,7 @@ func hasRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(args) != 2 {
-		usageErrorString := cmd.UsageString()
-		return fmt.Errorf("expected 2 arguments, got %d\n"+usageErrorString, len(args))
-	}
+	validateArgLenth(2, args, cmd)
 
 	appID := args[0]
 	entitlementID := args[1]

--- a/cmd/cone/login.go
+++ b/cmd/cone/login.go
@@ -20,7 +20,6 @@ func loginCmd() *cobra.Command {
 		Use:   "login <tenant-name or tenant-url>",
 		Short: fmt.Sprintf("Authenticate to ConductorOne, creating config.yaml in %s if it doesn't exist.", defaultConfigPath()),
 		RunE:  loginRun,
-		Args:  cobra.ExactArgs(1),
 	}
 
 	cmd.Flags().String("profile", "default", "Config profile to create or update.")
@@ -29,6 +28,11 @@ func loginCmd() *cobra.Command {
 
 func loginRun(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
+
+	if err := validateArgLenth(1, args, cmd); err != nil {
+		return err
+	}
+
 	tenant := args[0]
 
 	spinner, err := pterm.DefaultSpinner.Start("Logging in...")

--- a/cmd/cone/search_entitlements.go
+++ b/cmd/cone/search_entitlements.go
@@ -27,6 +27,9 @@ func searchEntitlementsRun(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateArgLenth(0, args, cmd); err != nil {
+		return err
+	}
 
 	query := v.GetString(queryFlag)
 	alias := v.GetString(entitlementAliasFlag)

--- a/cmd/cone/task_approve_deny.go
+++ b/cmd/cone/task_approve_deny.go
@@ -16,7 +16,6 @@ func approveTasksCmd() *cobra.Command {
 		Use:   "approve <task-id>",
 		Short: "Mark a task as approved",
 		RunE:  runApproveTasks,
-		Args:  cobra.ExactArgs(1),
 	}
 
 	addCommentFlag(cmd)
@@ -29,7 +28,6 @@ func denyTasksCmd() *cobra.Command {
 		Use:   "deny <task-id>",
 		Short: "Mark a task as denied",
 		RunE:  runDenyTasks,
-		Args:  cobra.ExactArgs(1),
 	}
 
 	addCommentFlag(cmd)
@@ -64,6 +62,10 @@ func runApproveDeny(
 ) error {
 	ctx, c, v, err := cmdContext(cmd)
 	if err != nil {
+		return err
+	}
+
+	if err := validateArgLenth(1, args, cmd); err != nil {
 		return err
 	}
 

--- a/cmd/cone/task_comment.go
+++ b/cmd/cone/task_comment.go
@@ -13,7 +13,6 @@ func tasksCommentCmd() *cobra.Command {
 		Use:   "comment <task-id> <comment>",
 		Short: "Adds the specified comment to a task",
 		RunE:  tasksCommentRun,
-		Args:  cobra.ExactArgs(2),
 	}
 
 	return cmd
@@ -22,6 +21,10 @@ func tasksCommentCmd() *cobra.Command {
 func tasksCommentRun(cmd *cobra.Command, args []string) error {
 	ctx, c, v, err := cmdContext(cmd)
 	if err != nil {
+		return err
+	}
+
+	if err := validateArgLenth(2, args, cmd); err != nil {
 		return err
 	}
 

--- a/cmd/cone/task_escalate.go
+++ b/cmd/cone/task_escalate.go
@@ -13,7 +13,6 @@ func escalateTasksCmd() *cobra.Command {
 		Use:   "escalate <task-id>",
 		Short: "Escalate an access request task to emergency access",
 		RunE:  runEscalateTasks,
-		Args:  cobra.ExactArgs(1),
 	}
 	return cmd
 }
@@ -21,6 +20,10 @@ func escalateTasksCmd() *cobra.Command {
 func runEscalateTasks(cmd *cobra.Command, args []string) error {
 	ctx, c, v, err := cmdContext(cmd)
 	if err != nil {
+		return err
+	}
+
+	if err := validateArgLenth(1, args, cmd); err != nil {
 		return err
 	}
 

--- a/cmd/cone/task_get.go
+++ b/cmd/cone/task_get.go
@@ -13,7 +13,6 @@ func getTasksCmd() *cobra.Command {
 		Use:   "get <task-id>",
 		Short: "Gets a task by id",
 		RunE:  getTaskRun,
-		Args:  cobra.ExactArgs(1),
 	}
 
 	return cmd
@@ -22,6 +21,10 @@ func getTasksCmd() *cobra.Command {
 func getTaskRun(cmd *cobra.Command, args []string) error {
 	ctx, c, v, err := cmdContext(cmd)
 	if err != nil {
+		return err
+	}
+
+	if err := validateArgLenth(1, args, cmd); err != nil {
 		return err
 	}
 

--- a/cmd/cone/task_search.go
+++ b/cmd/cone/task_search.go
@@ -39,6 +39,10 @@ func searchTasksRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := validateArgLenth(0, args, cmd); err != nil {
+		return err
+	}
+
 	var includeDeleted *bool
 	if v.Get(includeDeletedFlag) != nil {
 		includeDeletedVal := v.GetBool(includeDeletedFlag)

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -36,10 +36,7 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(args) != 0 {
-		usageErrorString := cmd.UsageString()
-		return fmt.Errorf("expected 0 arguments, got %d\n"+usageErrorString, len(args))
-	}
+	validateArgLenth(0, args, cmd)
 
 	tokenSrc, _, _, err := client.NewC1TokenSource(ctx, clientId, clientSecret)
 	if err != nil {

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -36,7 +36,9 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	validateArgLenth(0, args, cmd)
+	if err := validateArgLenth(0, args, cmd); err != nil {
+		return err
+	}
 
 	tokenSrc, _, _, err := client.NewC1TokenSource(ctx, clientId, clientSecret)
 	if err != nil {

--- a/cmd/cone/whoami.go
+++ b/cmd/cone/whoami.go
@@ -23,6 +23,10 @@ func whoAmIRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := validateArgLenth(0, args, cmd); err != nil {
+		return err
+	}
+
 	introspectResp, err := c.AuthIntrospect(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Removed the `cobra.ExactArgs()` call and implemented a new `validateArgLength()` function to all cone commands with a few exceptions with cone get/drop. This creates consistency across all of the current cone command arguments error output.