### PR TITLE
Added 'Bearer' in front of the bearer token for both the raw and default output

### DIFF
--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -59,7 +59,7 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 
 	if v.GetBool(rawTokenFlag) {
 		//nolint:forbidigo // We want to raw-print the bearer if this flag is included
-		fmt.Println("Bearer " + token.AccessToken)
+		fmt.Println(tokenObj.AccessToken)
 		return nil
 	}
 

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -52,14 +52,14 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 	}
 
 	tokenObj := Token{
-		AccessToken: token.AccessToken,
+		AccessToken: "Bearer " + token.AccessToken,
 		TokenType:   token.TokenType,
 		Expiry:      token.Expiry.String(),
 	}
 
 	if v.GetBool(rawTokenFlag) {
 		//nolint:forbidigo // We want to raw-print the bearer if this flag is included
-		fmt.Println(token.AccessToken)
+		fmt.Println("Bearer " + token.AccessToken)
 		return nil
 	}
 


### PR DESCRIPTION
Added 'Bearer' in front of the bearer token for both the raw and default output of 'cone token'
<img width="773" alt="image" src="https://github.com/ConductorOne/cone/assets/93247310/b1c58808-03d0-4f4b-8a60-2b066d034e04">
<img width="780" alt="image" src="https://github.com/ConductorOne/cone/assets/93247310/0704b2fd-eb55-4bc9-9a26-267bc4d832c0">

