### PR TITLE
Allow the API Endpoint to be optionally override + improve debug

### DIFF
--- a/cmd/cone/main.go
+++ b/cmd/cone/main.go
@@ -49,6 +49,7 @@ func runCli(ctx context.Context) int {
 	cliCmd.PersistentFlags().BoolP("non-interactive", "i", false, "Disable prompts.")
 	cliCmd.PersistentFlags().String("client-id", "", "Client ID")
 	cliCmd.PersistentFlags().String("client-secret", "", "Client secret")
+	cliCmd.PersistentFlags().String("api-endpoint", "", "Override the API endpoint")
 	cliCmd.PersistentFlags().StringP("output", "o", "table", "Output format. Valid values: table, json, json-pretty, wide.")
 	cliCmd.PersistentFlags().Bool("debug", false, "Enable debug logging")
 

--- a/cmd/cone/token.go
+++ b/cmd/cone/token.go
@@ -40,7 +40,10 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	tokenSrc, _, _, err := client.NewC1TokenSource(ctx, clientId, clientSecret)
+	tokenSrc, _, _, err := client.NewC1TokenSource(ctx,
+		clientId, clientSecret,
+		v.GetString("api-endpoint"), v.GetBool("debug"),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/uhttp/transport.go
+++ b/pkg/uhttp/transport.go
@@ -109,22 +109,25 @@ func (uat *debugTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return uat.next.RoundTrip(req)
 	}
 
-	resp, err := uat.next.RoundTrip(req)
+	authorizationHdr := req.Header.Get("Authorization")
+	if authorizationHdr != "" {
+		req.Header.Set("Authorization", "[REDACTED]")
+	}
+	requestBytes, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", authorizationHdr)
 
-	if req.Header.Get("Authorization") != "" {
-		req.Header.Set("Authorization", "[REDACTED]")
-	}
-
-	requestBytes, err := httputil.DumpRequest(req, true)
+	resp, err := uat.next.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
 
 	//nolint:forbidigo
 	fmt.Println(string(requestBytes))
+	//nolint:forbidigo
+	fmt.Println("")
 
 	responseBytes, err := httputil.DumpResponse(resp, true)
 	if err != nil {
@@ -132,6 +135,8 @@ func (uat *debugTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	//nolint:forbidigo
 	fmt.Println(string(responseBytes))
+	//nolint:forbidigo
+	fmt.Println("")
 
 	return resp, nil
 }


### PR DESCRIPTION
- Add new config option, `api-endpoint`, which can exist inside the profile for a cone config;  This makes local development more easy to persistently configure, and removes the inline Environment variable checks.
- Improve the accuracy of the debug output by using `httputil.DumpRequestOut`
- Make `debug` flag work for the Token endpoint
- Fix Request Body dumping in debug;  We weren't logging it correctly, it was showing up as empty.