### PR TITLE
Remove nil possibility

### DIFF
--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -50,6 +50,9 @@ func (e *HTTPError) Error() string {
 }
 
 func HandleErrors(ctx context.Context, v *viper.Viper, input error) error {
+	if v == nil {
+		return input
+	}
 	outputType := v.GetString("output")
 	if outputType != "json" && outputType != output.JSONPretty {
 		return input


### PR DESCRIPTION
There exists a case where cmdContext() returns an error. This would result in viper.Viper being nil and handle errors breaks.

```
`panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1454ae9]

goroutine 1 [running]:
github.com/spf13/viper.(*Viper).find(0x0, {0x18711e6, 0x6}, 0x1)
	/Users/runner/work/cone/cone/vendor/github.com/spf13/viper/viper.go:1236 +0x49
github.com/spf13/viper.(*Viper).Get(0x0, {0x18711e6?, 0x1f15e60?})
	/Users/runner/work/cone/cone/vendor/github.com/spf13/viper/viper.go:892 +0x4f
github.com/spf13/viper.(*Viper).GetString(0x16bf66e?, {0x18711e6?, 0x187754a?})
	/Users/runner/work/cone/cone/vendor/github.com/spf13/viper/viper.go:959 +0x1e
github.com/conductorone/cone/pkg/client.HandleErrors({0x1989fd8, 0xc0000ae050}, 0x1?, {0x1982f40, 0xc00009e110})
	/Users/runner/work/cone/cone/pkg/client/error.go:53 +0x5a
main.runCli({0x1989fd8?, 0xc0000ae050})
	/Users/runner/work/cone/cone/cmd/cone/main.go:77 +0x60d
main.main()
	/Users/runner/work/cone/cone/cmd/cone/main.go:31 +0x105`
```



