### PR TITLE
Cone Decrypt app id argument

### DIFF
--- a/cmd/cone/decrypt.go
+++ b/cmd/cone/decrypt.go
@@ -86,7 +86,7 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 	}
 
 	if validateArgLenth(0, args, cmd) != nil && validateArgLenth(1, args, cmd) != nil {
-		return fmt.Errorf("expected 1 or no arguments, got %d\n%s", len(args), cmd.UsageString())
+		return fmt.Errorf("expected 0 or 1 arguments, got %d\n%s", len(args), cmd.UsageString())
 	}
 
 	var apps []shared.App

--- a/cmd/cone/decrypt.go
+++ b/cmd/cone/decrypt.go
@@ -84,9 +84,8 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = validateArgLenth(0, args, cmd)
-	if err != nil || validateArgLenth(1, args, cmd) != nil {
-		return err
+	if validateArgLenth(0, args, cmd) != nil && validateArgLenth(1, args, cmd) != nil {
+		return fmt.Errorf("expected 1 or no arguments, got %d\n%s", len(args), cmd.UsageString())
 	}
 
 	var apps []shared.App

--- a/cmd/cone/decrypt.go
+++ b/cmd/cone/decrypt.go
@@ -22,7 +22,7 @@ import (
 
 func decryptCredentialCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "decrypt-credential <app-id>",
+		Use:   "decrypt-credential [app-id]",
 		Short: "Attempts to decrypt a credential",
 		RunE:  decryptCredentialRun,
 	}

--- a/cmd/cone/decrypt.go
+++ b/cmd/cone/decrypt.go
@@ -21,7 +21,7 @@ import (
 
 func decryptCredentialCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "decrypt-credential <encrypted-credential>",
+		Use:   "decrypt-credential <app-id>",
 		Short: "Attempts to decrypt a credential",
 		RunE:  decryptCredentialRun,
 	}
@@ -84,13 +84,21 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := validateArgLenth(0, args, cmd); err != nil {
+	err = validateArgLenth(0, args, cmd)
+	if err != nil || validateArgLenth(1, args, cmd) != nil {
 		return err
 	}
 
-	apps, err := c.ListApps(ctx)
-	if err != nil {
-		return err
+	var apps []shared.App
+
+	if len(args) > 0 {
+		apps = []shared.App{{ID: &args[0]}}
+
+	} else {
+		apps, err = c.ListApps(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	allCreds := make([]shared.AppUserCredential, 0)

--- a/cmd/cone/decrypt.go
+++ b/cmd/cone/decrypt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto/providers"
 	"github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk"
 	"github.com/conductorone/conductorone-sdk-go/pkg/models/shared"
+	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -74,7 +75,7 @@ func decodeCredential(ctx context.Context, v *viper.Viper, cred shared.AppUserCr
 		return nil, fmt.Errorf("failed to decrypt credential: %w", err)
 	}
 
-	fmt.Printf("Thumbprint: %s\n", thumbprint(privateJWK.Public()))
+	pterm.Printf("Thumbprint: %s\n", thumbprint(privateJWK.Public()))
 	return plaintext, nil
 }
 
@@ -119,7 +120,7 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("Found %d credentials\n", len(allCreds))
+	pterm.Printf("Found %d credentials\n", len(allCreds))
 	for _, cred := range allCreds {
 		plaintext, err := decodeCredential(ctx, v, cred)
 		if err != nil {
@@ -134,8 +135,8 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to marshal plaintext: %w", err)
 		}
-		fmt.Printf("Decrypted credential: %s\n", pt)
-		fmt.Printf("Decrypted bytes: %s\n", plaintext.Bytes)
+		pterm.Printf("Decrypted credential: %s\n", pt)
+		pterm.Printf("Decrypted bytes: %s\n", plaintext.Bytes)
 	}
 
 	return nil


### PR DESCRIPTION
Implements 'cone decrypt-credential <app id>' for running cone decrypt against a specific app instead of all apps