### PR TITLE
change decrypt credentials to only request your own creds

### DIFF
--- a/cmd/cone/decrypt.go
+++ b/cmd/cone/decrypt.go
@@ -104,6 +104,13 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Get the c1 user ID
+	resp, err := c.AuthIntrospect(ctx)
+	if err != nil {
+		return err
+	}
+	userID := client.StringFromPtr(resp.UserID)
+
 	allCreds := make([]shared.AppUserCredential, 0)
 
 	for _, app := range apps {
@@ -115,6 +122,9 @@ func decryptCredentialRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		for _, appUser := range appUsers {
+			if *appUser.GetIdentityUserID() != userID {
+				continue
+			}
 			creds, err := c.ListAppUserCredentials(ctx, *app.ID, *appUser.ID)
 			if err != nil {
 				return err


### PR DESCRIPTION
Changes "decrypt-credential" to only request credentials for app users you are the owner of.
This preempts a coming change to c1 that forbids requesting credentials for other users.