### PR TITLE
Properly filter app user credentials by matching key-id

### DIFF
--- a/cmd/cone/flags.go
+++ b/cmd/cone/flags.go
@@ -20,6 +20,7 @@ const (
 	notGrantedFlag       = "not-granted"
 	rawTokenFlag         = "raw"
 	appDisplayNameFlag   = "app"
+	showEncryptedFlag    = "show-encrypted"
 )
 
 func addWaitFlag(cmd *cobra.Command) {
@@ -77,4 +78,8 @@ func addRawTokenFlag(cmd *cobra.Command) {
 
 func addAppDisplayNameFlag(cmd *cobra.Command) {
 	cmd.Flags().String(appDisplayNameFlag, "", "The display name of the app to filter by.")
+}
+
+func addShowEncryptedFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool(showEncryptedFlag, false, "Show credentials we could not decrypt.")
 }


### PR DESCRIPTION
Updates decrypt-credential to hide non-decryptable credentials by default, and suggests the new --show-encrypted flag which shows them again if there are any.

Sanitized example response

```
cone decrypt-credential

Found 3 credential(s)
1 credential(s) successfully decrypted
2 credential(s) could not be decrypted
Use the --show-encrypted flag to see the encrypted credentials
========================================
App Display Name: Postgresql
App ID: 2prUoUzJWyMyrgRqvsK6lENwT5l
App User ID: 2pzcTmluIpBZA0CK7buLOYTArJU
Thumbprint: bad4ca89207e4ebf652d8c0d10f48b6f559cd526c024207f591ff5f09f4d74de
Decrypted Credential: [CENSORED]
========================================
```

```
cone decrypt-credential --show-encrypted

Found 3 credential(s)
1 credential(s) successfully decrypted
2 credential(s) could not be decrypted
========================================
App Display Name: Postgresql
App ID: 2prUoUzJWyMyrgRqvsK6lENwT5l
App User ID: 2pzcTmluIpBZA0CK7buLOYTArJU
Thumbprint: bad4ca89207e4ebf652d8c0d10f48b6f559cd526c024207f591ff5f09f4d74de
Decrypted Credential: [CENSORED]
========================================
========================================
App Display Name: Postgresql
App ID: 2prUoUzJWyMyrgRqvsK6lENwT5l
App User ID: 2pzcTmluIpBZA0CK7buLOYTArJU
Failed to decode credential: failed to decrypt credential: jwk-ed25519: age: failed to decrypt: no identity matched any of the recipients
========================================
========================================
App Display Name: Postgresql
App ID: 2prUoUzJWyMyrgRqvsK6lENwT5l
App User ID: 2pzcTmluIpBZA0CK7buLOYTArJU
Failed to decode credential: failed to decrypt credential: jwk-ed25519: age: failed to decrypt: no identity matched any of the recipients
========================================
```