### PR TITLE
Add cone version to user agent info

### DIFF
--- a/cmd/cone/main.go
+++ b/cmd/cone/main.go
@@ -21,7 +21,8 @@ func main() {
 	// Notify the channel for specified signals
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := context.WithValue(context.Background(), client.VersionKey, version)
+	ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
 		// Block until a signal is received

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 
 require (
 	github.com/conductorone/baton-sdk v0.2.35
-	github.com/conductorone/conductorone-sdk-go v1.22.0
+	github.com/conductorone/conductorone-sdk-go v1.23.0
 	github.com/pterm/pterm v0.12.62
 	github.com/toqueteos/webbrowser v1.2.0
 	github.com/xhit/go-str2duration/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/conductorone/baton-sdk v0.2.35 h1:aSdNvlM5HMti8WdhotrXTHWs+b+BmSqMxtGwsSUFxjY=
 github.com/conductorone/baton-sdk v0.2.35/go.mod h1:hmd/Oz3DPIKD+9QmkusZaA18ZoiinnTDdrxh2skcdUc=
-github.com/conductorone/conductorone-sdk-go v1.22.0 h1:sz9nz/85YZ0pJ/U3b63QEzE3WMSz6HuCjRTi/kb3mbU=
-github.com/conductorone/conductorone-sdk-go v1.22.0/go.mod h1:vr3946WqFYEpOuIGy/TqXkarhhCzHSKsmXXsxCmeIj8=
+github.com/conductorone/conductorone-sdk-go v1.23.0 h1:xRWsFNztcFEx4w+e1RRNbUyKaXzrIXk8htASQMAE39g=
+github.com/conductorone/conductorone-sdk-go v1.23.0/go.mod h1:vr3946WqFYEpOuIGy/TqXkarhhCzHSKsmXXsxCmeIj8=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -138,11 +138,9 @@ func New(
 	c.baseURL = &apiURL
 
 	var version = "dev"
-	switch v := ctx.Value(VersionKey).(type) {
-	case string:
-		if v != "" {
-			version = v
-		}
+
+	if v := ctx.Value(VersionKey).(string); v != "" {
+		version = v
 	}
 
 	c.sdk = sdk.New(

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -15,6 +16,10 @@ import (
 )
 
 const ConeClientID = "2RGdOS94VDferT9e80mdgntl36K"
+
+type contextKey string
+
+const VersionKey contextKey = "version"
 
 type client struct {
 	httpClient *http.Client
@@ -132,9 +137,18 @@ func New(
 	}
 	c.baseURL = &apiURL
 
+	var version = "dev"
+	switch v := ctx.Value(VersionKey).(type) {
+	case string:
+		if v != "" {
+			version = v
+		}
+	}
+
 	c.sdk = sdk.New(
 		sdk.WithClient(uclient),
 		sdk.WithServerURL(apiURL.String()),
+		sdk.WithExtraUserAgent(fmt.Sprintf("cone/%s", version)),
 	)
 
 	return c, nil

--- a/vendor/github.com/conductorone/conductorone-sdk-go/extra_sdk_options.go
+++ b/vendor/github.com/conductorone/conductorone-sdk-go/extra_sdk_options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -31,6 +32,12 @@ func WithTenant(input string) (SDKOption, error) {
 	}
 
 	return func(api *ConductoroneAPI) {}, nil
+}
+
+func WithExtraUserAgent(userAgent string) SDKOption {
+	return func(sdk *ConductoroneAPI) {
+		sdk.sdkConfiguration.UserAgent = fmt.Sprintf("%s %s", userAgent, sdk.sdkConfiguration.UserAgent)
+	}
 }
 
 type CustomSDKOption func(*CustomOptions)

--- a/vendor/github.com/conductorone/conductorone-sdk-go/extra_sdk_options.go
+++ b/vendor/github.com/conductorone/conductorone-sdk-go/extra_sdk_options.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -16,12 +15,6 @@ import (
 
 const c1TenantDomain = ".conductor.one"
 const ClientIdGolangSDK = "2RCzHlak5q7CY14SdBc8HoZEJRf"
-
-func WithExtraUserAgent(userAgent string) SDKOption {
-	return func(sdk *ConductoroneAPI) {
-		sdk.sdkConfiguration.UserAgent = fmt.Sprintf("%s %s", userAgent, sdk.sdkConfiguration.UserAgent)
-	}
-}
 
 func WithTenant(input string) (SDKOption, error) {
 	resp, err := NormalizeTenant(input)

--- a/vendor/github.com/conductorone/conductorone-sdk-go/extra_sdk_options.go
+++ b/vendor/github.com/conductorone/conductorone-sdk-go/extra_sdk_options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -15,6 +16,12 @@ import (
 
 const c1TenantDomain = ".conductor.one"
 const ClientIdGolangSDK = "2RCzHlak5q7CY14SdBc8HoZEJRf"
+
+func WithExtraUserAgent(userAgent string) SDKOption {
+	return func(sdk *ConductoroneAPI) {
+		sdk.sdkConfiguration.UserAgent = fmt.Sprintf("%s %s", userAgent, sdk.sdkConfiguration.UserAgent)
+	}
+}
 
 func WithTenant(input string) (SDKOption, error) {
 	resp, err := NormalizeTenant(input)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,7 +28,7 @@ github.com/cenkalti/backoff/v4
 github.com/conductorone/baton-sdk/pb/c1/connector/v2
 github.com/conductorone/baton-sdk/pkg/crypto/providers
 github.com/conductorone/baton-sdk/pkg/crypto/providers/jwk
-# github.com/conductorone/conductorone-sdk-go v1.22.0
+# github.com/conductorone/conductorone-sdk-go v1.23.0
 ## explicit; go 1.21
 github.com/conductorone/conductorone-sdk-go
 github.com/conductorone/conductorone-sdk-go/internal/hooks


### PR DESCRIPTION
Passes along the versioning info to the SDK to put in user agent
Relies on SDK change in review here: https://github.com/ConductorOne/conductorone-sdk-go/pull/84

Here's the observed user agent when using the change (taken from dev proxy logs)
`"cone/dev speakeasy-sdk/go 1.22.0 2.452.0 0.1.0-alpha github.com/conductorone/conductorone-sdk-go"`
or with a mocked MJP version 
`"cone/MJP speakeasy-sdk/go 1.22.0 2.452.0 0.1.0-alpha github.com/conductorone/conductorone-sdk-go"`

TODO
- [x] Replace temporary vendor patch with actual SDK update 