### PR TITLE
When displaying multiple appUsers to choose from, show aws_user_type if it exists

### DIFF
--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -361,6 +361,19 @@ func runTask(
 	return nil
 }
 
+func getAppUserProfileAttribute(appUserProfile map[string]any, profileAttribute string) string {
+	if appUserProfile == nil {
+		return ""
+	}
+
+	attrValue, ok := appUserProfile[profileAttribute]
+	if !ok {
+		return ""
+	}
+
+	return fmt.Sprintf("%v", attrValue)
+}
+
 func getAppUserId(ctx context.Context, c client.C1Client, v *viper.Viper, appId, userId string) (string, error) {
 	appUsers, err := c.ListAppUsersForUser(ctx, appId, userId)
 	if err != nil {
@@ -389,6 +402,11 @@ func getAppUserId(ctx context.Context, c client.C1Client, v *viper.Viper, appId,
 				client.StringFromPtr(au.AppID),
 				client.StringFromPtr(au.ID),
 			)
+			// If exists, append the aws user type to help differentiate between appUsers with the same name.
+			awsUserType := getAppUserProfileAttribute(au.GetProfile(), "aws_user_type")
+			if awsUserType != "" {
+				appUserOptionName = fmt.Sprintf("%s (%s)", appUserOptionName, awsUserType)
+			}
 			appUsersOptions = append(appUsersOptions, appUserOptionName)
 			optionToAppUsersMap[appUserOptionName] = &appUser
 		}

--- a/cmd/cone/get_drop_task.go
+++ b/cmd/cone/get_drop_task.go
@@ -362,7 +362,7 @@ func runTask(
 }
 
 func getAppUserProfileAttribute(appUserProfile map[string]any, profileAttribute string) string {
-	if appUserProfile == nil {
+	if len(appUserProfile) == 0 || profileAttribute == "" {
 		return ""
 	}
 


### PR DESCRIPTION
This will help the user distinguish between AWS app users that have the same name but have different types (e.g. `sso` vs `iam`).